### PR TITLE
Fix GPR file / Fix numerous style flaws

### DIFF
--- a/adaid_debug.gpr
+++ b/adaid_debug.gpr
@@ -1,23 +1,22 @@
 library project AdaID_Debug is
-	for Library_Name use "adaid_debug";
-	for Object_Dir use "obj/debug";
-	for Source_Dirs use ("src");
-	for Library_Dir use "lib";
-	for Library_Kind use "static";
-	for Library_ALI_Dir use "ali/debug";
-	
-	package Builder is
-		for Default_Switches("Ada") use ("-g",
-										"-Wall",
-										"-Wextra", 
-										"-gnatQ");
-	end Builder;
-	package Compiler is
-		for Default_Switches("Ada") use ("-g",
-										"-Wall",
-										"--pedantic-errors",
-										"-Wextra",
-										"-I./include");
-	end Compiler;
-	
+
+   for Library_Name use "adaid_debug";
+   for Object_Dir use "obj/debug";
+   for Source_Dirs use ("src", "include");
+   for Library_Dir use "lib";
+   for Library_Kind use "static";
+   for Library_Ali_Dir use "ali/debug";
+
+   package Builder is
+      for Default_Switches ("ada") use ("-g");
+   end Builder;
+
+   package Compiler is
+      for Default_Switches ("ada") use ("-gnatyabBCeiklmnpxAfh");
+   end Compiler;
+
+   package Linker is
+   end Linker;
+
 end AdaID_Debug;
+

--- a/adaid_debug.gpr
+++ b/adaid_debug.gpr
@@ -12,7 +12,7 @@ library project AdaID_Debug is
    end Builder;
 
    package Compiler is
-      for Default_Switches ("ada") use ("-gnatyabBCeiklmnpxAfh");
+      for Default_Switches ("ada") use ("-gnatyabBCeiklmnpxAfht");
    end Compiler;
 
    package Linker is

--- a/include/adaid-generate.ads
+++ b/include/adaid-generate.ads
@@ -13,17 +13,20 @@ package AdaID.Generate is
    -- Thrown when invalid strings are passed to From_String
 
 
-   procedure Nil(id : in out UUID);
+   procedure Nil (id : in out UUID);
    -- Set a UUID to Nil
 
 
-   procedure Random(id : in out UUID);
+   procedure Random (id : in out UUID);
    -- Generate a random UUID
 
-   procedure From_Name(namespace: in UUID; name: in String; id: in out UUID);
+   procedure From_Name
+     (namespace : in UUID;
+      name      : in String;
+      id        : in out UUID);
    -- Generate a UUID based on a name
 
-   procedure From_String(str : in String; id : in out UUID);
+   procedure From_String (str : in String; id : in out UUID);
    -- Generate a UUID from a string.
    -- This is not so much generation, but reconstruction
 

--- a/include/adaid.ads
+++ b/include/adaid.ads
@@ -12,7 +12,7 @@ with Interfaces; use Interfaces; -- for Unsigned_n
 -- the UUID type.
 package AdaID is
 
-   uuid_size: constant Integer := 16;
+   uuid_size : constant Integer := 16;
    -- This many bytes in a UUID
 
    subtype HashType is Unsigned_32;
@@ -21,7 +21,7 @@ package AdaID is
    type Byte is mod 2 ** 8;
    -- Byte Type (2^8)
 
-   type ByteArray is array (0 .. uuid_size-1) of Byte;
+   type ByteArray is array (0 .. uuid_size - 1) of Byte;
    -- Byte Array for UUID data storage
 
    type VersionType is (
@@ -45,29 +45,29 @@ package AdaID is
 
    type UUID is new Ada.Finalization.Controlled with
       record
-         data: ByteArray;
+         data : ByteArray;
       end record;
    -- The main type for the package
 
-   function Is_Nil(This: in UUID) return Boolean;
+   function Is_Nil (This : in UUID) return Boolean;
    -- Determine if UUID is NIL (All Zeros)
 
-   function Get_Version(This: in UUID) return VersionType;
+   function Get_Version (This : in UUID) return VersionType;
    -- Get the UUID Version
 
-   function Get_Variant(This: in UUID) return VariantType;
+   function Get_Variant (This : in UUID) return VariantType;
    -- Get the UUID Variant
 
-   function "="(Left, Right: in UUID) return Boolean;
+   function "="(Left, Right : in UUID) return Boolean;
    -- Test for equality between Left and Right
 
-   function Get_Hash_Value(This: in UUID) return HashType;
+   function Get_Hash_Value (This : in UUID) return HashType;
    -- Get the hash code for the UUID
 
-   function To_String(This: in UUID) return String;
+   function To_String (This : in UUID) return String;
    -- Convert the UUID to a common string representation
 
 private
-   overriding procedure Initialize (This: in out UUID);
+   overriding procedure Initialize (This : in out UUID);
    -- Default "constructor", initializes to NIL
 end AdaID;

--- a/include/adaid.ads
+++ b/include/adaid.ads
@@ -50,24 +50,24 @@ package AdaID is
    -- The main type for the package
 
    function Is_Nil(This: in UUID) return Boolean;
-   --Determine if UUID is NIL (All Zeros)
+   -- Determine if UUID is NIL (All Zeros)
 
    function Get_Version(This: in UUID) return VersionType;
-   --Get the UUID Version
+   -- Get the UUID Version
 
    function Get_Variant(This: in UUID) return VariantType;
-   --Get the UUID Variant
+   -- Get the UUID Variant
 
    function "="(Left, Right: in UUID) return Boolean;
-   --Test for equality between Left and Right
+   -- Test for equality between Left and Right
 
    function Get_Hash_Value(This: in UUID) return HashType;
-   --Get the hash code for the UUID
+   -- Get the hash code for the UUID
 
    function To_String(This: in UUID) return String;
-   --Convert the UUID to a common string representation
+   -- Convert the UUID to a common string representation
 
 private
    overriding procedure Initialize (This: in out UUID);
-   --Default "constructor", initializes to NIL
+   -- Default "constructor", initializes to NIL
 end AdaID;

--- a/src/adaid-generate.adb
+++ b/src/adaid-generate.adb
@@ -14,7 +14,7 @@ package body AdaID.Generate is
    package RNG is new Ada.Numerics.Discrete_Random(Result_Subtype =>
                                                      Unsigned_32);
    generator: RNG.Generator;
-   generator_is_set: Boolean := false;
+   generator_is_set: Boolean := False;
 
 
    procedure Seed_RNG is
@@ -34,12 +34,12 @@ package body AdaID.Generate is
             when others =>
                RNG.Reset(generator); -- Fallback to time-based
          end;
-         generator_is_set := true;
+         generator_is_set := True;
       end if;
    end Seed_RNG;
 
 
-   --Reset a UUID to Nil
+   -- Reset a UUID to Nil
    procedure Nil(id : in out UUID) is
    begin
       Initialize(id);
@@ -69,12 +69,12 @@ package body AdaID.Generate is
       -- Set the variant
       id.data(8) := (id.data(8) and 16#BF#) or 16#80#;
 
-      --Set the version to random-number-based
+      -- Set the version to random-number-based
       id.data(6) := (id.data(6) and 16#4F#) or 16#40#;
-   end;
+   end Random;
 
 
-   --Generate a UUID based on a name
+   -- Generate a UUID based on a name
    procedure From_Name(namespace: in UUID; name: in String; id: in out UUID) is
       use SHA.Process_Data;
 
@@ -93,7 +93,7 @@ package body AdaID.Generate is
          Add(SHA.Process_Data.Byte(Character'Pos(name(i))), c);
       end loop;
 
-      --Get the digest
+      -- Get the digest
       Finalize(d, c);
 
       -- Now make the UUID from the hash
@@ -107,7 +107,7 @@ package body AdaID.Generate is
       -- set variant
       id.data(8) := (id.data(8) and 16#BF#) or 16#80#;
 
-      --set version
+      -- set version
       id.data(6) := (id.data(6) and 16#5F#) or 16#50#;
    end From_Name;
 
@@ -120,10 +120,10 @@ package body AdaID.Generate is
       close : constant Character := '}';
 
       -- expect dashes if str is 36 or 38 in length
-      dashed: constant Boolean := str'Length = 36 or str'Length = 38;
+      dashed: constant Boolean := str'Length = 36 or else str'Length = 38;
 
       -- check to see if braces surround the string
-      braced: constant Boolean := str(str'First) = open and
+      braced: constant Boolean := str(str'First) = open and then
         str(str'Last) = close;
 
       -- track where to read from/write to
@@ -132,14 +132,15 @@ package body AdaID.Generate is
    begin
 
       -- Check that length is valid
-      if not dashed and str'Length /= 32 and str'Length /= 34 then
+      if not dashed and then str'Length /= 32 and then str'Length /= 34 then
          raise Invalid_String;
       end if;
 
       -- Check that brace are valid
       start := str'First;
-      if not braced and
-        (str(str'First) = open or str(str'Last) = close) then
+      if not braced and then
+        (str(str'First) = open or else str(str'Last) = close)
+      then
          raise Invalid_String; -- only one brace present
       elsif braced then
          start := str'First + 1;
@@ -150,7 +151,9 @@ package body AdaID.Generate is
       -- Grab each pair and stuff into byte
       for i in ByteArray'Range loop
          rel := idx - start;
-         if dashed and (rel = 8 or rel = 13 or rel = 18 or rel = 23) then
+         if dashed and then
+           (rel = 8 or else rel = 13 or else rel = 18 or else rel = 23)
+         then
             if str(idx) /= delim then
                raise Invalid_String; -- expected '-'
             end if;

--- a/src/adaid-generate.adb
+++ b/src/adaid-generate.adb
@@ -11,10 +11,10 @@ use Ada.Streams.Stream_IO;
 package body AdaID.Generate is
 
    -- For RNG
-   package RNG is new Ada.Numerics.Discrete_Random(Result_Subtype =>
-                                                     Unsigned_32);
-   generator: RNG.Generator;
-   generator_is_set: Boolean := False;
+   package RNG is new Ada.Numerics.Discrete_Random (Result_Subtype =>
+                                                       Unsigned_32);
+   generator : RNG.Generator;
+   generator_is_set : Boolean := False;
 
 
    procedure Seed_RNG is
@@ -27,12 +27,12 @@ package body AdaID.Generate is
             Open   (File => file,
                     Mode => In_File,
                     Name => "/dev/urandom");
-            Integer'Read (Stream(file), seed);
-            Close(file);
-            RNG.Reset(generator, seed);
+            Integer'Read (Stream (file), seed);
+            Close (file);
+            RNG.Reset (generator, seed);
          exception
             when others =>
-               RNG.Reset(generator); -- Fallback to time-based
+               RNG.Reset (generator); -- Fallback to time-based
          end;
          generator_is_set := True;
       end if;
@@ -40,14 +40,14 @@ package body AdaID.Generate is
 
 
    -- Reset a UUID to Nil
-   procedure Nil(id : in out UUID) is
+   procedure Nil (id : in out UUID) is
    begin
-      Initialize(id);
+      Initialize (id);
    end Nil;
 
 
    -- Generate a random UUID
-   procedure Random(id : in out UUID) is
+   procedure Random (id : in out UUID) is
       rand : Unsigned_32;
       x : Integer := 0;
    begin
@@ -55,76 +55,80 @@ package body AdaID.Generate is
       Seed_RNG;
 
       -- Get a random number
-      rand := RNG.Random(generator);
+      rand := RNG.Random (generator);
 
       for i in ByteArray'Range loop
          if x = 4 then
             x := 0;
-            rand := RNG.Random(generator);
+            rand := RNG.Random (generator);
          end if;
-         id.data(i) := Byte(shift_right(rand, x * 8) and 16#FF#);
+         id.data (i) := Byte (shift_right (rand, x * 8) and 16#FF#);
          x := x + 1;
       end loop;
 
       -- Set the variant
-      id.data(8) := (id.data(8) and 16#BF#) or 16#80#;
+      id.data (8) := (id.data (8) and 16#BF#) or 16#80#;
 
       -- Set the version to random-number-based
-      id.data(6) := (id.data(6) and 16#4F#) or 16#40#;
+      id.data (6) := (id.data (6) and 16#4F#) or 16#40#;
    end Random;
 
 
    -- Generate a UUID based on a name
-   procedure From_Name(namespace: in UUID; name: in String; id: in out UUID) is
+   procedure From_Name
+     (namespace : in UUID;
+      name      : in String;
+      id        : in out UUID)
+   is
       use SHA.Process_Data;
 
       c : Context;
       d : SHA.Digest;
    begin
-      Initialize(c);
+      Initialize (c);
 
       -- Start SHA1 hashing with namespace uuid
       for i in namespace.data'Range loop
-         Add(SHA.Process_Data.Byte(namespace.data(i)), c);
+         Add (SHA.Process_Data.Byte (namespace.data (i)), c);
       end loop;
 
       -- Continuing hashing the actual name
       for i in name'Range loop
-         Add(SHA.Process_Data.Byte(Character'Pos(name(i))), c);
+         Add (SHA.Process_Data.Byte (Character'Pos (name (i))), c);
       end loop;
 
       -- Get the digest
-      Finalize(d, c);
+      Finalize (d, c);
 
       -- Now make the UUID from the hash
       for i in 0 .. 3 loop
-         id.data(i*4+0) := Byte(shift_right(d(i), 24) and 16#FF#);
-         id.data(i*4+1) := Byte(shift_right(d(i), 16) and 16#FF#);
-         id.data(i*4+2) := Byte(shift_right(d(i),  8) and 16#FF#);
-         id.data(i*4+3) := Byte(shift_right(d(i),  0) and 16#FF#);
+         id.data (i * 4 + 0) := Byte (shift_right (d (i), 24) and 16#FF#);
+         id.data (i * 4 + 1) := Byte (shift_right (d (i), 16) and 16#FF#);
+         id.data (i * 4 + 2) := Byte (shift_right (d (i),  8) and 16#FF#);
+         id.data (i * 4 + 3) := Byte (shift_right (d (i),  0) and 16#FF#);
       end loop;
 
       -- set variant
-      id.data(8) := (id.data(8) and 16#BF#) or 16#80#;
+      id.data (8) := (id.data (8) and 16#BF#) or 16#80#;
 
       -- set version
-      id.data(6) := (id.data(6) and 16#5F#) or 16#50#;
+      id.data (6) := (id.data (6) and 16#5F#) or 16#50#;
    end From_Name;
 
 
    -- Generate a UUID from a string.
    -- This is not so much generation, but reconstruction
-   procedure From_String(str : in String; id : in out UUID) is
-      delim: constant Character := '-';
+   procedure From_String (str : in String; id : in out UUID) is
+      delim : constant Character := '-';
       open : constant Character := '{';
       close : constant Character := '}';
 
       -- expect dashes if str is 36 or 38 in length
-      dashed: constant Boolean := str'Length = 36 or else str'Length = 38;
+      dashed : constant Boolean := str'Length = 36 or else str'Length = 38;
 
       -- check to see if braces surround the string
-      braced: constant Boolean := str(str'First) = open and then
-        str(str'Last) = close;
+      braced : constant Boolean := str (str'First) = open and then
+        str (str'Last) = close;
 
       -- track where to read from/write to
       idx : Integer := 0;
@@ -139,7 +143,7 @@ package body AdaID.Generate is
       -- Check that brace are valid
       start := str'First;
       if not braced and then
-        (str(str'First) = open or else str(str'Last) = close)
+        (str (str'First) = open or else str (str'Last) = close)
       then
          raise Invalid_String; -- only one brace present
       elsif braced then
@@ -154,13 +158,13 @@ package body AdaID.Generate is
          if dashed and then
            (rel = 8 or else rel = 13 or else rel = 18 or else rel = 23)
          then
-            if str(idx) /= delim then
+            if str (idx) /= delim then
                raise Invalid_String; -- expected '-'
             end if;
             idx := idx + 1;
          end if;
          -- Convert to byte
-         id.data(i) := Byte'Value("16#" & str(idx .. idx+1) & "#");
+         id.data (i) := Byte'Value ("16#" & str (idx .. idx + 1) & "#");
          idx := idx + 2;
       end loop;
    end From_String;

--- a/src/adaid.adb
+++ b/src/adaid.adb
@@ -10,20 +10,20 @@ package body AdaID is
       for i in ByteArray'Range loop
          This.data(i) := 0;
       end loop;
-   end;
+   end Initialize;
 
    -- Determine if the UUID is NIL
    function Is_Nil(This: in UUID) return Boolean is
    begin
       for i in ByteArray'Range loop
          if This.data(i) /= 0 then
-            return false;
+            return False;
          end if;
       end loop;
-      return true;
+      return True;
    end Is_Nil;
 
-   --Get the UUID Version
+   -- Get the UUID Version
    function Get_Version(This: in UUID) return VersionType is
       -- version type in octet 7
       b : constant Byte := This.data(6) and Byte(16#F0#);
@@ -38,7 +38,7 @@ package body AdaID is
       end case;
    end Get_Version;
 
-   --Get the UUID Variant
+   -- Get the UUID Variant
    function Get_Variant(This: in UUID) return VariantType is
       -- variant type in octet 9
       b : constant Byte := This.data(8);
@@ -54,19 +54,19 @@ package body AdaID is
       end if;
    end Get_Variant;
 
-   --Test for equality
+   -- Test for equality
    function "="(Left, Right: in UUID) return Boolean is
    begin
       for i in ByteArray'Range loop
          if Left.data(i) /= Right.data(i) then
-            return false;
+            return False;
          end if;
       end loop;
-      return true;
+      return True;
    end "=";
 
 
-   --Get the hash value for the UUID
+   -- Get the hash value for the UUID
    function Get_Hash_Value(This: in UUID) return HashType is
       seed : HashType := 0;
    begin
@@ -83,7 +83,7 @@ package body AdaID is
       return seed;
    end Get_Hash_Value;
 
-   --Convert the UUID to a string
+   -- Convert the UUID to a string
    function To_String(This: in UUID) return String is
       result : String(1 .. 36);
       index : Integer := 1;
@@ -98,7 +98,7 @@ package body AdaID is
          index := index + 2;
 
          -- insert dashes
-         if i = 3 or i = 5 or i = 7 or i = 9 then
+         if i = 3 or else i = 5 or else i = 7 or else i = 9 then
             result(index) := '-';
             index := index + 1;
          end if;

--- a/src/adaid.adb
+++ b/src/adaid.adb
@@ -5,18 +5,18 @@
 
 package body AdaID is
    -- Default "Constructor" for NIL UUID
-   overriding procedure Initialize(This: in out UUID) is
+   overriding procedure Initialize (This : in out UUID) is
    begin
       for i in ByteArray'Range loop
-         This.data(i) := 0;
+         This.data (i) := 0;
       end loop;
    end Initialize;
 
    -- Determine if the UUID is NIL
-   function Is_Nil(This: in UUID) return Boolean is
+   function Is_Nil (This : in UUID) return Boolean is
    begin
       for i in ByteArray'Range loop
-         if This.data(i) /= 0 then
+         if This.data (i) /= 0 then
             return False;
          end if;
       end loop;
@@ -24,9 +24,9 @@ package body AdaID is
    end Is_Nil;
 
    -- Get the UUID Version
-   function Get_Version(This: in UUID) return VersionType is
+   function Get_Version (This : in UUID) return VersionType is
       -- version type in octet 7
-      b : constant Byte := This.data(6) and Byte(16#F0#);
+      b : constant Byte := This.data (6) and Byte (16#F0#);
    begin
       case b is
          when 16#10# => return Time_Based;
@@ -39,9 +39,9 @@ package body AdaID is
    end Get_Version;
 
    -- Get the UUID Variant
-   function Get_Variant(This: in UUID) return VariantType is
+   function Get_Variant (This : in UUID) return VariantType is
       -- variant type in octet 9
-      b : constant Byte := This.data(8);
+      b : constant Byte := This.data (8);
    begin
       if (b and 16#80#) = 0 then
          return NCS;
@@ -55,10 +55,10 @@ package body AdaID is
    end Get_Variant;
 
    -- Test for equality
-   function "="(Left, Right: in UUID) return Boolean is
+   function "="(Left, Right : in UUID) return Boolean is
    begin
       for i in ByteArray'Range loop
-         if Left.data(i) /= Right.data(i) then
+         if Left.data (i) /= Right.data (i) then
             return False;
          end if;
       end loop;
@@ -67,39 +67,39 @@ package body AdaID is
 
 
    -- Get the hash value for the UUID
-   function Get_Hash_Value(This: in UUID) return HashType is
+   function Get_Hash_Value (This : in UUID) return HashType is
       seed : HashType := 0;
    begin
       -- Hashing (in case it's needed)
       for i in ByteArray'Range loop
          seed := seed xor
            (
-            HashType(This.data(i))
+            HashType (This.data (i))
               + 16#9E3779B9#
-              + shift_left(seed, 6)
-              + shift_right(seed, 2)
+              + shift_left (seed, 6)
+              + shift_right (seed, 2)
            );
       end loop;
       return seed;
    end Get_Hash_Value;
 
    -- Convert the UUID to a string
-   function To_String(This: in UUID) return String is
-      result : String(1 .. 36);
+   function To_String (This : in UUID) return String is
+      result : String (1 .. 36);
       index : Integer := 1;
       base : constant Integer := 2 ** 4;
-      chars : constant String(1 .. base) := "0123456789abcdef";
+      chars : constant String (1 .. base) := "0123456789abcdef";
       b : Integer;
    begin
       for i in ByteArray'Range loop
-         b := Integer(This.data(i)); -- get byte to convert
-         result(index) := chars(b / base + 1); -- convert hi bits
-         result(index + 1) := chars(b mod base + 1); -- convert lo bits
+         b := Integer (This.data (i)); -- get byte to convert
+         result (index) := chars (b / base + 1); -- convert hi bits
+         result (index + 1) := chars (b mod base + 1); -- convert lo bits
          index := index + 2;
 
          -- insert dashes
          if i = 3 or else i = 5 or else i = 7 or else i = 9 then
-            result(index) := '-';
+            result (index) := '-';
             index := index + 1;
          end if;
       end loop;

--- a/src/sha-process_data.adb
+++ b/src/sha-process_data.adb
@@ -168,7 +168,8 @@ package body SHA.Process_Data is
       --  We may have to make room for the count to be put on the last block.
       if Given.Next_Word >= Given.Data'Last - 1 then -- Room for the count?
          if not (Given.Next_Word = Given.Data'Last - 1
-                 and Given.Remaining_Bits = 32) then
+                 and then Given.Remaining_Bits = 32)
+         then
             Transform (Given);
          end if;
       end if;


### PR DESCRIPTION
The GPR file contained a number of wrong flags, duplicate flags, and mishandled how to "include" Ada source files.  Those have all been corrected.

At the same time, a number of standard style checks were added and the changes enforced.  This was done in two passes (the token spacing was done as a separate commit since it caused numerous corrections and masked other changes).
