### PR TITLE
Fix for building using FSF GNAT 9

### DIFF
--- a/adaid.gpr.in
+++ b/adaid.gpr.in
@@ -2,7 +2,7 @@ library project AdaID is
 	Version := "%VERSION%";
 	for Library_Name use "adaid";
 	for Object_Dir use "obj";
-	for Source_Dirs use ("src");
+	for Source_Dirs use ("src", "include");
 	for Library_Dir use "lib";
 	for Library_Kind use "dynamic";
 	for Library_ALI_Dir use "ali";

--- a/test.gpr
+++ b/test.gpr
@@ -9,10 +9,7 @@ project Test is
 	
 	package Builder is
 		for Default_Switches("Ada") use ("-g",
-										"-Wall",
-										"-Wextra", 
-										"-gnatQ", 
-										"-I./include");
+										"-gnatQ");
 	end Builder;
 	
 	
@@ -28,8 +25,7 @@ project Test is
 										"-g",
 										"-Wall",
 										"--pedantic-errors",
-										"-Wextra", 
-										"-I./include");
+										"-Wextra");
 	end Compiler;
 	
 	package Binder is


### PR DESCRIPTION
These changes are necessary for building under FSF GNAT 9 (Ubuntu 20.04).